### PR TITLE
Thread-safe/Time-safe generateNonce

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ did.AddManagementKey(mgmtKey)
 
 // Generate Service
 // NewService(alias, serviceType, endpoint)
-service, err := factomdid.NewManagementKey("service-alias", "KYC", "https://kyc.example.com")
+service, err := factomdid.NewService("service-alias", "KYC", "https://kyc.example.com")
 if err != nil {
   // handle error
 }

--- a/helpers.go
+++ b/helpers.go
@@ -3,18 +3,25 @@ package factomdid
 import (
 	"fmt"
 	"math/rand"
+	"sync"
 	"time"
 
 	"github.com/FactomProject/factom"
 )
 
+var rng *rand.Rand
+var rngMtx sync.Mutex
+
+func init() {
+	rng = rand.New(rand.NewSource(time.Now().UnixNano()))
+}
+
 // generateNonce() generates random 32 bytes nonce
 func generateNonce() []byte {
-
-	rand.Seed(time.Now().UnixNano())
-
 	nonce := make([]byte, 64)
-	rand.Read(nonce)
+	rngMtx.Lock()
+	rng.Read(nonce)
+	rngMtx.Unlock()
 
 	return nonce
 }


### PR DESCRIPTION
The unit test for generateNonce() kept failing for me because the two calls for generateNonce() both instantiated the RNG with the same nanosecond.

This change will instantiate a non thread-safe random number generator once when the app starts, then every call to rng.Read will produce a unique result.